### PR TITLE
Fix tts not working when creating a new chat

### DIFF
--- a/src/app/(main)/project/[project_id]/chat/[chat_id]/page.tsx
+++ b/src/app/(main)/project/[project_id]/chat/[chat_id]/page.tsx
@@ -7,20 +7,28 @@ import { Chat, ChatConverseStream, ChatMessageType } from "@/types/chat";
 import { API } from "@/utils/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 export default function Chat(params: { params: { project_id: string, chat_id: string } }) {
-    
+
     const { project_id, chat_id } = params.params;
+    const searchParams = useSearchParams();
     const [newChat, setNewChat] = useState("");
     const [chatMessage, setChatMessage] = useState<string>("");
     const [storage] = useAtom(storageAtom);
     const [isTyping, setIsTyping] = useState<boolean>(false);
-    
+
     const chatQuery = useQuery(["chat", chat_id], () => API.chat.get(project_id, chat_id));
     const chat: Chat | undefined = chatQuery.data;
 
     const openai_key = !storage?.user?.allow_key || storage?.override_api_key ? storage?.openai_api_key : undefined
+    const shouldAutoPlay = searchParams?.get("autoplay") !== null;
+
+    useEffect(() => {
+        const uri = window.location.toString();
+        if (uri.indexOf("?") > 0) window.history.replaceState({}, document.title, uri.substring(0, uri.indexOf("?")));
+    }, [])
 
     const streamChatMessage = async (message: ChatConverseStream) => {
         if (newChat === "") setNewChat(message.input);
@@ -28,7 +36,7 @@ export default function Chat(params: { params: { project_id: string, chat_id: st
             const updatedChatMessage = prevChatMessage + message.delta;
             return updatedChatMessage;
         });
-        if(message.stop) setIsTyping(false);
+        if (message.stop) setIsTyping(false);
     };
 
     const chatUpdateMutation = useMutation((language: string) => API.chat.update(project_id, chat_id, { language }), {
@@ -84,7 +92,7 @@ export default function Chat(params: { params: { project_id: string, chat_id: st
         <div className="h-screen flex flex-col flex-1">
             <div className="flex-1 overflow-auto" ref={messagesContainerRef}>
                 {chat?.chats?.map((message, i) => (
-                    <ChatBlock message={message} key={message.external_id} autoplay={!!chatMessage && (i === (chat?.chats?.length || 0) - 1)} />
+                    <ChatBlock message={message} key={message.external_id} autoplay={(!!chatMessage || shouldAutoPlay) && (i === (chat?.chats?.length || 0) - 1)} />
                 ))}
                 {chatMessage && (<>
                     <ChatBlock message={{ messageType: ChatMessageType.USER, message: newChat, created_at: "", external_id: "", modified_at: "" }} />

--- a/src/app/(main)/project/[project_id]/page.tsx
+++ b/src/app/(main)/project/[project_id]/page.tsx
@@ -24,21 +24,16 @@ export default function Chat(params: { params: { project_id: string } }) {
     const openai_key = !storage?.user?.allow_key || storage?.override_api_key ? storage?.openai_api_key : undefined
 
     useEffect(() => {
-        if (!isTyping && chatID) router.push(`/project/${project_id}/chat/${chatID}`);
+        if (!isTyping && chatID) router.push(`/project/${project_id}/chat/${chatID}?autoplay`);
     }, [chatID, isTyping]);
 
     const streamChatMessage = async (message: ChatConverseStream) => {
-        if (message.ayushma_voice) {
-            // play audio from source url
-            const audio = new Audio(message.ayushma_voice);
-            audio.play();
-        }
         if (chat === "") setChat(message.input);
         setChatMessage(prevChatMessage => {
             const updatedChatMessage = prevChatMessage + message.delta;
             return updatedChatMessage;
         });
-        if(message.stop) setIsTyping(false);
+        if (message.stop) setIsTyping(false);
     };
 
     const converseMutation = useMutation((external_id: string) => API.chat.converse(project_id, external_id, chat, !storage.user?.allow_key || storage.override_api_key ? storage.openai_api_key : undefined, streamChatMessage, 20), {


### PR DESCRIPTION
Fixes #15 
- We now use a query parameter `autoplay` to convey our chat page to autoplay the first message
- This parameter is hidden from the browser's URL

https://github.com/coronasafe/ayushma_fe/assets/3626859/a29c1b65-6ac1-4224-89aa-ce0481113dae

