### PR TITLE
Fixed cancel and update profile buttons moving on /profile url.

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -106,7 +106,9 @@ export default function Page() {
                   Passwords do not match
                 </p>
               ) : (
-                <p className="text-transparent text-sm mb-2">Hidden Text</p>
+                <p className="text-transparent select-none text-sm mb-2">
+                  &nbsp;
+                </p>
               )}
               <div className="flex gap-2 py-4">
                 <Button

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -101,10 +101,12 @@ export default function Page() {
                   }
                 />
               </div>
-              {formData.password != formData.confirm_password && (
+              {formData.password != formData.confirm_password ? (
                 <p className="text text-sm text-red-500 mb-2">
                   Passwords do not match
                 </p>
+              ) : (
+                <p className="text-transparent text-sm mb-2">Hidden Text</p>
               )}
               <div className="flex gap-2 py-4">
                 <Button


### PR DESCRIPTION
Issue Addressed: #39 

What was solved:
The buttons were moving when the password and confirm password weren't matching.

How was it solved:
I added a dummy invisible text to replace the passwords don't match text. So the new text takes up space and wouldn't let the buttons move above.

References: 

Before:
https://github.com/coronasafe/ayushma_fe/assets/73941119/8058fc59-856c-42a5-bc00-c76cb0327359

After/ Proposed Changes:
https://github.com/coronasafe/ayushma_fe/assets/73941119/dcbba38a-efd5-44ef-8970-1a8009ba69ce

