### PR TITLE
Add STT engine option to ProjectForm

### DIFF
--- a/src/components/forms/projectform.tsx
+++ b/src/components/forms/projectform.tsx
@@ -1,4 +1,4 @@
-import { Project } from "@/types/project";
+import { Project, STT_ENGINES } from "@/types/project";
 import { useState } from "react";
 import { Button, Input, TextArea } from "../ui/interactive";
 
@@ -38,6 +38,15 @@ export default function ProjectForm(props: {
                     onChange={(e) => setProject({ ...project, prompt: e.target.value })}
                     errors={errors?.prompt}
                 />
+                <select
+                    className="border border-gray-200 w-full bg-white rounded-lg relative transition-all flex ring-0 ring-green-500 focus-within:ring-2 focus-within:ring-offset-1 p-3"
+                    value={project.stt_engine || "whisper"}
+                    onChange={(e) => setProject({ ...project, stt_engine: e.target.value })}
+                >
+                    {STT_ENGINES.map((engine, i) => (
+                        <option key={i} value={engine.id}>{engine.label}</option>
+                    ))}
+                </select>
                 <Button
                     loading={loading}
                     type="submit"

--- a/src/components/forms/projectform.tsx
+++ b/src/components/forms/projectform.tsx
@@ -40,11 +40,11 @@ export default function ProjectForm(props: {
                 />
                 <select
                     className="border border-gray-200 w-full bg-white rounded-lg relative transition-all flex ring-0 ring-green-500 focus-within:ring-2 focus-within:ring-offset-1 p-3"
-                    value={project.stt_engine || "whisper"}
-                    onChange={(e) => setProject({ ...project, stt_engine: e.target.value })}
+                    value={project.stt_engine || 1}
+                    onChange={(e) => setProject({ ...project, stt_engine: parseInt(e.target.value) })}
                 >
                     {STT_ENGINES.map((engine, i) => (
-                        <option key={i} value={engine.id}>{engine.label}</option>
+                        <option key={engine.id} value={engine.id}>{engine.label}</option>
                     ))}
                 </select>
                 <Button

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -5,6 +5,7 @@ export type Project = BaseModelType & {
     description: string,
     is_default: boolean,
     prompt?: string,
+    stt_engine: string,
 }
 
 export enum DocumentType {
@@ -12,6 +13,11 @@ export enum DocumentType {
     URL = 2,
     TEXT = 3
 }
+
+export const STT_ENGINES = [
+    { id: 'whisper', label: 'OpenAI Whisper' },
+    { id: 'google', label: 'Google Speech to Text' },
+]
 
 export type Document = BaseModelType & {
     title: string,

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -5,7 +5,7 @@ export type Project = BaseModelType & {
     description: string,
     is_default: boolean,
     prompt?: string,
-    stt_engine: string,
+    stt_engine: number,
 }
 
 export enum DocumentType {
@@ -15,8 +15,8 @@ export enum DocumentType {
 }
 
 export const STT_ENGINES = [
-    { id: 'whisper', label: 'OpenAI Whisper' },
-    { id: 'google', label: 'Google Speech to Text' },
+    { id: 1, label: 'OpenAI Whisper' },
+    { id: 2, label: 'Google Speech to Text' },
 ]
 
 export type Document = BaseModelType & {


### PR DESCRIPTION
This commit adds a select element to the ProjectForm where users can select a STT engine to be used with their project. STT engines' names and IDs are defined in the STT_ENGINES constant. Also, the Project type definition now includes the stt_engine property.

![image](https://github.com/coronasafe/ayushma_fe/assets/3626859/2d82b406-9fe7-48ab-b227-4984e9c61ee6)

Backend: https://github.com/coronasafe/ayushma/pull/191