### PR TITLE
Add default ordering for project list

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -161,7 +161,7 @@ export const API = {
         reset: (token: string, email: string, password: string) => request("auth/reset", "POST", { token, email, password }),
     },
     projects: {
-        list: () => request("projects"),
+        list: (filters: { ordering: string } = { ordering: "-created_at" }) => request("projects","GET", filters),
         get: (id: string) => request(`projects/${id}`),
         update: (id: string, project: Partial<Project>) => request(`projects/${id}`, "PATCH", { ...project }),
         create: (project: Partial<Project>) => request(`projects`, "POST", { ...project }),


### PR DESCRIPTION
Fixes #55 

Projects are now shown from latest creation time to the oldest.