### PR TITLE
Show error message on new test suite form

### DIFF
--- a/src/app/admin/tests/new/page.tsx
+++ b/src/app/admin/tests/new/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
                     testSuite={{}}
                     onSubmit={onSubmit}
                     loading={createTestSuiteMutation.isLoading}
-                    errors={(createTestSuiteMutation.error as any)?.errors}
+                    errors={(createTestSuiteMutation.error as any)?.error}
                 />
             </div>
         </div>

--- a/src/app/admin/tests/page.tsx
+++ b/src/app/admin/tests/page.tsx
@@ -17,14 +17,14 @@ export default function Page() {
                     Test Suites
                 </h1>
                 <div className="grid grid-cols-4 gap-4 mt-8">
+                    <Link href={`/admin/tests/new`} className="border border-dashed border-gray-300 hover:bg-gray-100 bg-white rounded-lg p-4">
+                        <i className="far fa-plus" /> New Test Suite
+                    </Link>
                     {testSuites.map((testSuite, i) => (
                         <Link href={`/admin/tests/${testSuite.external_id}`} key={i} className="border border-gray-300 hover:bg-gray-100 bg-white rounded-lg p-4">
                             {testSuite.name}
                         </Link>
                     ))}
-                    <Link href={`/admin/tests/new`} className="border border-dashed border-gray-300 hover:bg-gray-100 bg-white rounded-lg p-4">
-                        <i className="far fa-plus" /> New Test Suite
-                    </Link>
                 </div>
             </div>
         </div>

--- a/src/components/forms/testsuiteform.tsx
+++ b/src/components/forms/testsuiteform.tsx
@@ -26,6 +26,7 @@ export default function TestSuiteForm(props: {
                     placeholder="Name"
                     value={testSuite.name}
                     onChange={(e) => setTestSuite({ ...testSuite, name: e.target.value })}
+                    errors={errors?.name}
                 />
                 Temperature< br />
                 <Slider
@@ -35,6 +36,7 @@ export default function TestSuiteForm(props: {
                     step={0.1}
                     max={1}
                     onChange={(val) => setTestSuite({ ...testSuite, temperature: val })}
+                    errors={errors?.temperature}
                 />
                 TopK<br />
                 <Slider
@@ -44,6 +46,7 @@ export default function TestSuiteForm(props: {
                     step={1}
                     max={100}
                     onChange={(val) => setTestSuite({ ...testSuite, topk: val })}
+                    errors={errors?.topk}
                 />
                 <div className="grid grid-cols-2 gap-4 mt-4">
                     <Button

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,3 +1,5 @@
+import { Errors } from "./interactive";
+
 export default function Slider(props: {
     max: number,
     min?: number,
@@ -7,6 +9,7 @@ export default function Slider(props: {
     disabled?: boolean,
     left?: React.ReactNode,
     right?: React.ReactNode,
+    errors?: string[],
 }) {
 
     const { max, min = 0, value, onChange, step = 1, disabled } = props;
@@ -34,6 +37,7 @@ export default function Slider(props: {
                 disabled={disabled}
                 className="w-full slider"
             />
+            <Errors errors={props.errors} />
         </div>
     )
 }


### PR DESCRIPTION
Fixes #137 
http://localhost:3000/admin/tests/new
- Show the error message when an empty New Test Suite form is submitted
![image](https://github.com/coronasafe/ayushma_fe/assets/70687348/acaa17f0-a6c6-46c4-8716-0cd0c6f4435a)

- Place the `New Test Suite` button at the start
![image](https://github.com/coronasafe/ayushma_fe/assets/70687348/66ba2bcf-f69d-4c8d-8a82-131e0fe98a79)
