### PR TITLE
Update Next Config: App Dir is no longer epxerimental since next 13.4

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   output: 'standalone',
   distDir: 'build'
 };


### PR DESCRIPTION
<img width="713" alt="image" src="https://github.com/coronasafe/ayushma_fe/assets/25143503/999faf3d-6cb9-4341-8e41-38a9db2e6c09">

### Changes:
- Drop appDir experimental from next config since we are in next 14

### Reference:

- https://nextjs.org/docs/app/api-reference/next-config-js/appDir
  > This option is no longer needed as of Next.js 13.4. The App Router is now stable.