### PR TITLE
Stop Playing Audio When Switched to a Different Chat

### DIFF
--- a/src/components/chatblock.tsx
+++ b/src/components/chatblock.tsx
@@ -85,7 +85,10 @@ export default function ChatBlock(props: {
       const interval = setInterval(() => {
         setPercentagePlayed((audio.currentTime / audio.duration) * 100);
       }, 10);
-      return () => clearInterval(interval);
+      return () => {
+        stopAudio();
+        clearInterval(interval);
+      };
     }
   }, [audio]);
 


### PR DESCRIPTION
# Related Issue
Fixes #168 

# Description 
I have used the existing `useEffect` on `src/components/chatblock.tsx` to stop the audio when the ChatBlock component unmounts. That way whenever the chat is switched the current playing component unmounts and hence stops the audio.
