### PR TITLE
Fix chat list pagination

### DIFF
--- a/src/components/sidebar/chatSidebar.tsx
+++ b/src/components/sidebar/chatSidebar.tsx
@@ -23,14 +23,15 @@ export default function ChatSideBar(props: { project_id?: string }) {
   const debouncedSearchQuery = useDebounce(searchQuery, 1000);
   const chatsQuery = useInfiQuery({
     queryKey: ["search", debouncedSearchQuery],
-    queryFn: ({ pageParam = 0 }) => {
-      return API.chat.list(
+    queryFn: async ({ pageParam = 0 }) => {
+      const res = await API.chat.list(
         project_id || "",
         {
           offset: pageParam,
           search: debouncedSearchQuery
         },
       );
+      return { ...res, offset: pageParam };
     },
     enabled: !!project_id,
   },

--- a/src/utils/hooks/useInfiQuery.tsx
+++ b/src/utils/hooks/useInfiQuery.tsx
@@ -20,7 +20,7 @@ export const useInfiQuery: (options: InfiQueryProps) => InfiQueryResult<any> = (
     queryKey,
     queryFn,
     initialPageParam: 0,
-    getNextPageParam: (lastPage: any) => lastPage.has_next ? lastPage.offset + (fetchLimit || 10) : undefined,
+    getNextPageParam: (lastPage: any) => lastPage.has_next ? (lastPage.offset ?? 0) + (fetchLimit ?? 10) : undefined,
   });
 
   const loadMore = () => {


### PR DESCRIPTION
This pull request fixes the pagination issue in the chat list. Previously, the offset value was not correctly calculated when loading more chat items. This caused duplicate items to be displayed when scrolling. The issue has been resolved by updating the `getNextPageParam` function in the `useInfiQuery` hook to correctly calculate the offset value.