### PR TITLE
Fix new chat creation during initial empty STT

### DIFF
--- a/src/app/(main)/project/[project_id]/page.tsx
+++ b/src/app/(main)/project/[project_id]/page.tsx
@@ -63,11 +63,11 @@ export default function Chat(params: { params: { project_id: string } }) {
         ),
       retry: false,
       onSuccess: async (data, vars) => {
+        setChatID(data.external_id);
         await converseMutation.mutateAsync({
           external_id: data.external_id,
           formdata: vars.formdata,
         });
-        setChatID(data.external_id);
       },
     },
   );


### PR DESCRIPTION
This pull request fixes an issue where the chat creation was not working properly during the initial empty STT. The setChatID function was being called in the wrong place, causing the chat ID to be set after the converseMutation was called. This resulted in incorrect behavior. The fix moves the setChatID function call to the correct location, ensuring that the chat ID is set before the converseMutation is called.